### PR TITLE
feat: populate Code item description with deep link; fix name truncation

### DIFF
--- a/src/jama_client/client.py
+++ b/src/jama_client/client.py
@@ -16,6 +16,7 @@ are short-lived, typically lasting the duration of one server session.
 from __future__ import annotations
 
 import asyncio
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
@@ -53,6 +54,11 @@ _M = TypeVar("_M", bound=BaseModel)
 _DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 _NETWORK_RETRY_LIMIT = 2
 _NETWORK_RETRY_BASE_DELAY = 0.5
+# Matches a trailing ":N-M" line-range suffix, e.g. ":7-42". Used to strip the
+# suffix before deriving a Code item name and to extract start/end lines for URL
+# construction. Anchored on "$" so it does not match mid-path colons (ISO
+# timestamps, Windows paths, annotated identifiers, etc.).
+_LINE_RANGE_RE = re.compile(r":(\d+)-(\d+)$")
 
 
 class JamaClient:
@@ -527,6 +533,7 @@ class JamaClient:
         code_path: str,
         code_version: str,
         *,
+        repo_origin: str | None = None,
         name: str | None = None,
         code_set_id: int | None = None,
         code_item_type: int | None = None,
@@ -549,24 +556,56 @@ class JamaClient:
            match on ``"Implementation Code"`` when ``code_set_id`` is omitted;
            caches the result. Raises :class:`~jama_client.exceptions.JamaNotFoundError`
            when no match or multiple matches are found without an explicit ID.
-        5. Creates the Code item (name derived from the code path's basename
-           when ``name`` is not provided).
+        5. Creates the Code item. The ``name`` defaults to the basename of
+           ``code_path`` with any trailing ``:N-M`` line-range suffix stripped
+           (e.g. ``"src/client.py:7-42"`` → ``"client.py"``); mid-path colons
+           (ISO timestamps, Windows-style paths, annotated identifiers) are
+           preserved. When ``repo_origin`` is supplied, populates the item's
+           ``description`` field with a four-line deep link to the tagged code
+           (see ``repo_origin`` parameter description below).
         6. Creates the "Implemented by" relationship from the source requirement
            to the new Code item.
+
+        ``source_requirement_key`` accepts a Jama document key (e.g.
+        ``"AF-SUBSS-25"``), which this method resolves to a numeric ID
+        internally. By contrast, ``create_item`` and ``create_relationship``
+        accept numeric IDs only; callers composing those primitives directly
+        must resolve keys themselves.
 
         Args:
             project_id: The Jama project ID containing the source requirement
                 and the target Implementation Code Set.
             source_requirement_key: The document key (e.g. ``"AF-SUBSS-25"``)
-                of the source requirement.
+                of the source requirement. Resolved to a numeric ID internally
+                — callers do not need a prior ``search_items`` call.
             code_path: File path string stored in the Code item's
                 ``path$<typeId>`` field (e.g.
-                ``"src/detection/detector.py:7-42"``).
+                ``"src/detection/detector.py:7-42"``). A trailing ``:N-M``
+                suffix is recognised as a line range; any other colon is
+                treated as part of the path.
             code_version: Version string stored in the Code item's
                 ``code_version$<typeId>`` field (e.g. ``"v1.0.0-rc1"``).
+            repo_origin: Optional ``<host>/<owner>/<repo>`` string identifying
+                the source repository, e.g.
+                ``"github.com/arthurfantaci/jama-mcp-server"``. No leading
+                scheme; ``https://`` is prepended when constructing the deep
+                link. When supplied, the Code item's ``description`` field is
+                populated with:
+
+                .. code-block:: text
+
+                    Repository: <repo_origin>
+                    Version: <code_version>
+                    Path: <path-without-line-range> (lines N-M)
+                    Link: https://<repo_origin>/blob/<code_version>/<path>#LN-LM
+
+                The ``Path:`` and ``Link:`` lines omit the ``(lines N-M)``
+                annotation and ``#LN-LM`` fragment when no line range is
+                present in ``code_path``. When ``None`` (default), no
+                ``description`` field is set on the Code item.
             name: Optional override for the Code item's ``name`` field.
-                Defaults to the basename of ``code_path`` (excluding any
-                trailing ``:line-range`` suffix).
+                Defaults to the basename of ``code_path`` with any trailing
+                ``:N-M`` line-range suffix stripped.
             code_set_id: Optional explicit parent Set ID for the new Code item.
                 When omitted, the Set is resolved by name.
             code_item_type: Optional explicit item type ID for Code items.
@@ -602,17 +641,35 @@ class JamaClient:
             else await self._resolve_implementation_code_set(project_id)
         )
 
-        derived_name = name if name is not None else Path(code_path.split(":", maxsplit=1)[0]).name
+        stripped_path = _LINE_RANGE_RE.sub("", code_path)
+        derived_name = name if name is not None else Path(stripped_path).name
+
+        code_fields: dict[str, Any] = {
+            f"path${resolved_code_item_type}": code_path,
+            f"code_version${resolved_code_item_type}": code_version,
+        }
+        if repo_origin is not None:
+            range_match = _LINE_RANGE_RE.search(code_path)
+            if range_match:
+                start_line, end_line = range_match.group(1), range_match.group(2)
+                path_line = f"Path: {stripped_path} (lines {start_line}-{end_line})"
+                link = (
+                    f"https://{repo_origin}/blob/{code_version}"
+                    f"/{stripped_path}#L{start_line}-L{end_line}"
+                )
+            else:
+                path_line = f"Path: {stripped_path}"
+                link = f"https://{repo_origin}/blob/{code_version}/{stripped_path}"
+            code_fields["description"] = (
+                f"Repository: {repo_origin}\nVersion: {code_version}\n{path_line}\nLink: {link}"
+            )
 
         code_item = await self.create_item(
             project_id=project_id,
             item_type=resolved_code_item_type,
             parent=resolved_code_set_id,
             name=derived_name,
-            fields={
-                f"path${resolved_code_item_type}": code_path,
-                f"code_version${resolved_code_item_type}": code_version,
-            },
+            fields=code_fields,
         )
 
         relationship = await self.create_relationship(

--- a/src/jama_mcp_server/tools/workflow.py
+++ b/src/jama_mcp_server/tools/workflow.py
@@ -39,6 +39,7 @@ def register(server: FastMCP) -> None:
         source_requirement_key: str,
         code_path: str,
         code_version: str,
+        repo_origin: str | None = None,
         name: str | None = None,
         code_set_id: int | None = None,
         code_item_type: int | None = None,
@@ -49,15 +50,29 @@ def register(server: FastMCP) -> None:
         Workflow tool — composes core primitives; NOT expected in Jama Connect
         MCP™. High-level workflow for ``project_id`` that, given
         ``source_requirement_key`` (a document key like ``"AF-SUBSS-25"``),
-        ``code_path`` (e.g. ``"src/detection/detector.py:7-42"``), and
-        ``code_version`` (e.g. ``"v1.0.0-rc1"``):
+        ``code_path`` (e.g. ``"src/detection/detector.py:7-42"``),
+        ``code_version`` (e.g. ``"v1.0.0-rc1"``), and optionally
+        ``repo_origin`` (e.g. ``"github.com/arthurfantaci/jama-mcp-server"``):
 
         1. Validates the source requirement exists (returns an error before
-           any write if the key cannot be resolved).
-        2. Creates a Code item in the Implementation Code Set with
-           ``path`` and ``code_version`` fields populated; the item ``name``
-           defaults to the basename of ``code_path`` (excluding any trailing
-           ``:line-range`` suffix) unless overridden by the ``name`` parameter.
+           any write if the key cannot be resolved). ``source_requirement_key``
+           is a Jama document key — no prior ``search_items`` call is needed.
+           By contrast, ``create_relationship`` and ``create_comment`` accept
+           numeric item IDs only.
+        2. Creates a Code item in the Implementation Code Set with ``path``
+           and ``code_version`` fields populated; the item ``name`` defaults to
+           the basename of ``code_path`` with any trailing ``:N-M`` line-range
+           suffix stripped (mid-path colons such as ISO timestamps are
+           preserved). When ``repo_origin`` is supplied, also populates the
+           item ``description`` with a four-line deep link in the form::
+
+               Repository: <repo_origin>
+               Version: <code_version>
+               Path: <path-without-range> (lines N-M)
+               Link: https://<repo_origin>/blob/<code_version>/<path>#LN-LM
+
+           The ``(lines N-M)`` annotation and ``#LN-LM`` fragment are omitted
+           when ``code_path`` carries no trailing line range.
         3. Creates an ``"Implemented by"`` relationship from the source
            requirement to the new Code item.
 
@@ -75,6 +90,7 @@ def register(server: FastMCP) -> None:
             source_requirement_key=source_requirement_key,
             code_path=code_path,
             code_version=code_version,
+            repo_origin=repo_origin,
             name=name,
             code_set_id=code_set_id,
             code_item_type=code_item_type,

--- a/tests/unit/jama_client/test_client_dx_testing.py
+++ b/tests/unit/jama_client/test_client_dx_testing.py
@@ -1,0 +1,159 @@
+"""Unit tests for DX-testing phase changes to JamaClient.create_path_a_trace.
+
+Covers: name-derivation truncation regex correctness (baseline preservation on
+non-line-range colons; regression on trailing ``:N-M``), description-text
+format (with and without line range), and ``repo_origin`` propagation through
+to the ``create_item`` request payload.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from jama_client.client import JamaClient
+from jama_client.models import Item, Relationship
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client() -> AsyncMock:
+    """Return an AsyncMock configured as a JamaClient with stubbed sub-methods."""
+    client = AsyncMock(spec=JamaClient)
+    client._type_cache = {}
+    client._http = object()
+    client._find_item_by_key = AsyncMock(
+        return_value=Item(id=115100, item_type=87, project=127, document_key="AF-SUBSS-25")
+    )
+    client._resolve_code_item_type = AsyncMock(return_value=114)
+    client._resolve_implemented_by_rel_type = AsyncMock(return_value=19)
+    client._resolve_implementation_code_set = AsyncMock(return_value=212)
+    client.create_item = AsyncMock(return_value=Item(id=115200, item_type=114, project=127))
+    client.create_relationship = AsyncMock(
+        return_value=Relationship(id=18600, from_item=115100, to_item=115200, relationship_type=19)
+    )
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Truncation regex — Change A
+# ---------------------------------------------------------------------------
+
+
+async def test_name_derivation_preserves_basename_on_non_line_range_colon() -> None:
+    """Basename is unchanged when code_path contains a colon that is not a trailing line range.
+
+    The old first-colon truncation would have produced ``events`` from
+    ``src/handlers/events:custom-handler.py``; the anchored ``:\\d+-\\d+$``
+    regex must leave the basename ``events:custom-handler.py`` intact.
+    """
+    client = _make_client()
+    await JamaClient.create_path_a_trace(
+        client,
+        project_id=127,
+        source_requirement_key="AF-SUBSS-25",
+        code_path="src/handlers/events:custom-handler.py",
+        code_version="v1.0.0",
+    )
+    call_kwargs = client.create_item.call_args.kwargs
+    assert call_kwargs["name"] == "events:custom-handler.py"
+
+
+async def test_name_derivation_strips_trailing_line_range() -> None:
+    """Trailing ``:N-M`` is stripped from the basename; the rest of the path is preserved."""
+    client = _make_client()
+    await JamaClient.create_path_a_trace(
+        client,
+        project_id=127,
+        source_requirement_key="AF-SUBSS-25",
+        code_path="src/detection/occlusion_detector.py:7-42",
+        code_version="v1.0.0-rc1",
+    )
+    call_kwargs = client.create_item.call_args.kwargs
+    assert call_kwargs["name"] == "occlusion_detector.py"
+
+
+# ---------------------------------------------------------------------------
+# Description population — Change B
+# ---------------------------------------------------------------------------
+
+
+async def test_description_populated_with_line_range_matches_spec_format() -> None:
+    """Description matches the four-line spec format when a trailing line range is present."""
+    client = _make_client()
+    await JamaClient.create_path_a_trace(
+        client,
+        project_id=127,
+        source_requirement_key="AF-SUBSS-26",
+        code_path="src/jama_mcp_server/tools/workflow.py:78-130",
+        code_version="v1.0.0",
+        repo_origin="github.com/arthurfantaci/jama-mcp-server",
+    )
+    call_kwargs = client.create_item.call_args.kwargs
+    description: str = call_kwargs["fields"]["description"]
+    expected = (
+        "Repository: github.com/arthurfantaci/jama-mcp-server\n"
+        "Version: v1.0.0\n"
+        "Path: src/jama_mcp_server/tools/workflow.py (lines 78-130)\n"
+        "Link: https://github.com/arthurfantaci/jama-mcp-server"
+        "/blob/v1.0.0/src/jama_mcp_server/tools/workflow.py#L78-L130"
+    )
+    assert description == expected
+
+
+async def test_description_populated_without_line_range_omits_annotation_and_fragment() -> None:
+    """Description omits the ``(lines N-M)`` annotation and ``#LN-LM`` fragment when absent."""
+    client = _make_client()
+    await JamaClient.create_path_a_trace(
+        client,
+        project_id=127,
+        source_requirement_key="AF-SUBSS-27",
+        code_path="src/jama_client/client.py",
+        code_version="v1.0.0",
+        repo_origin="github.com/arthurfantaci/jama-mcp-server",
+    )
+    call_kwargs = client.create_item.call_args.kwargs
+    description: str = call_kwargs["fields"]["description"]
+    expected = (
+        "Repository: github.com/arthurfantaci/jama-mcp-server\n"
+        "Version: v1.0.0\n"
+        "Path: src/jama_client/client.py\n"
+        "Link: https://github.com/arthurfantaci/jama-mcp-server"
+        "/blob/v1.0.0/src/jama_client/client.py"
+    )
+    assert description == expected
+
+
+async def test_repo_origin_propagates_description_to_create_item_fields() -> None:
+    """When repo_origin is supplied, description is present in the fields passed to create_item."""
+    client = _make_client()
+    await JamaClient.create_path_a_trace(
+        client,
+        project_id=127,
+        source_requirement_key="AF-SUBSS-25",
+        code_path="src/jama_client/client.py:523-628",
+        code_version="abc1234",
+        repo_origin="github.com/arthurfantaci/jama-mcp-server",
+    )
+    call_kwargs = client.create_item.call_args.kwargs
+    assert "description" in call_kwargs["fields"]
+    assert "github.com/arthurfantaci/jama-mcp-server" in call_kwargs["fields"]["description"]
+    assert "abc1234" in call_kwargs["fields"]["description"]
+    assert "#L523-L628" in call_kwargs["fields"]["description"]
+
+
+async def test_description_absent_when_repo_origin_is_none() -> None:
+    """No description field is added to create_item when repo_origin is omitted."""
+    client = _make_client()
+    await JamaClient.create_path_a_trace(
+        client,
+        project_id=127,
+        source_requirement_key="AF-SUBSS-25",
+        code_path="src/jama_client/client.py:7-42",
+        code_version="v1.0.0",
+    )
+    call_kwargs = client.create_item.call_args.kwargs
+    assert "description" not in call_kwargs["fields"]

--- a/tests/unit/jama_mcp_server/test_protocol.py
+++ b/tests/unit/jama_mcp_server/test_protocol.py
@@ -253,6 +253,42 @@ async def test_create_path_a_trace_call_round_trips_via_protocol(
         source_requirement_key="AF-SUBSS-25",
         code_path="src/detection/detector.py:7-42",
         code_version="v1.0.0-rc1",
+        repo_origin=None,
+        name=None,
+        code_set_id=None,
+        code_item_type=None,
+        relationship_type=None,
+    )
+
+
+async def test_create_path_a_trace_passes_repo_origin_to_client(
+    server: FastMCP,
+    mock_jama_client: AsyncMock,
+) -> None:
+    """repo_origin is forwarded from the MCP tool call to the client method."""
+    mock_jama_client.create_path_a_trace.return_value = {
+        "source_item_id": 115100,
+        "code_item_id": 115200,
+        "relationship_id": 18600,
+    }
+    ctx = _make_context(mock_jama_client, server)
+    with patch.object(server, "get_context", return_value=ctx):
+        await server.call_tool(
+            "create_path_a_trace",
+            {
+                "project_id": 127,
+                "source_requirement_key": "AF-SUBSS-26",
+                "code_path": "src/jama_mcp_server/tools/workflow.py:78-130",
+                "code_version": "v1.0.0",
+                "repo_origin": "github.com/arthurfantaci/jama-mcp-server",
+            },
+        )
+    mock_jama_client.create_path_a_trace.assert_called_once_with(
+        project_id=127,
+        source_requirement_key="AF-SUBSS-26",
+        code_path="src/jama_mcp_server/tools/workflow.py:78-130",
+        code_version="v1.0.0",
+        repo_origin="github.com/arthurfantaci/jama-mcp-server",
         name=None,
         code_set_id=None,
         code_item_type=None,


### PR DESCRIPTION
Closes #15

## Summary

Hardens `create_path_a_trace` in two ways bundled together because they share the same `_LINE_RANGE_RE` anchoring code path. Change A fixes a name-derivation bug where the first colon in a code path was used as a truncation point, corrupting basenames that contain non-line-range colons (ISO timestamps, annotated identifiers). Change B adds a `repo_origin` parameter to both the `JamaClient` method and the MCP workflow tool that, when supplied, populates the new Code item's `description` field with a four-line deep link (Repository, Version, Path, Link) pointing reviewers directly to the tagged code in the repository.

## Acceptance criteria

- [x] `_LINE_RANGE_RE = re.compile(r":(\d+)-(\d+)$")` replaces first-colon truncation; mid-path colons in basenames are preserved
- [x] `repo_origin: str | None = None` is a keyword-only parameter on `JamaClient.create_path_a_trace` and the MCP workflow tool
- [x] When `repo_origin` is supplied, the Code item's `description` field is populated with the four-line format from spec Section 6.2
- [x] Line-range annotation `(lines N-M)` and URL fragment `#LN-LM` are present when `code_path` carries a trailing `:N-M` suffix; absent otherwise
- [x] When `repo_origin` is `None` (default), no `description` field is added to the Code item
- [x] Docstrings updated on both layers to reflect `repo_origin`, description-population behavior, and the macro-vs-primitives key-resolution asymmetry
- [x] 7 new tests: 6 client-layer (`tests/unit/jama_client/test_client_dx_testing.py`) + 1 MCP-protocol (`tests/unit/jama_mcp_server/test_protocol.py`)
- [x] All 126 tests pass (119 original + 7 new); 7 integration tests deselected

## Verification

| Command | Result |
|---|---|
| `uv run ruff check .` | ✅ All checks passed |
| `uv run ruff format --check .` | ✅ 36 files already formatted |
| `uv run mypy src/` | ✅ Success: no issues found in 13 source files |
| `uv run pytest -m "not integration"` | ✅ 126 passed, 7 deselected |

## Routine prompt (reproducibility)

<details>
<summary>Cloud routine prompt verbatim</summary>

```
You are implementing the work described in the design specification at `docs/superpowers/specs/2026-05-11-jama-mvp-dx-testing-design.md`. Follow that specification precisely, especially Section 6 (Bundled implementation pull request). This prompt configures your runtime constraints.

The repository is public on GitHub; commits are reviewed by potential employers including Jama Software engineers. Every commit must meet professional standards. No emojis in code or commit messages, no debug print statements, no commented-out code, no narrative comments referencing the assistant by name.

## Bypass permissions

bypassPermissions: yes — you are operating in a cloud routine environment with appropriate sandboxing. Run shell commands, edit files, run tests, and commit, push, and open the pull request without per-action confirmation.

## Scope

Implement the bundled pull request described in Section 6 of the design specification. Closes #15.

Two changes to `JamaClient.create_path_a_trace` in `src/jama_client/client.py` and the MCP workflow tool wrapper in `src/jama_mcp_server/tools/workflow.py`:

1. **Truncation regex fix** (spec Section 6.1). Replace the first-colon truncation in the Code item name-derivation logic with a regex anchored on `:\d+-\d+$`, stripping only trailing line-ranges. Code paths containing non-line-range colons (ISO timestamps, embedded annotations, Windows-style paths) must keep their basename intact.

2. **Repository origin parameter + deep-link description** (spec Section 6.2). Add a `repo_origin: str` parameter to both `JamaClient.create_path_a_trace` and the MCP workflow tool wrapper. Expected value format: `<host>/<owner>/<repo>` (no leading scheme, e.g. `github.com/arthurfantaci/jama-mcp-server`). Construct the description text per the exact format in spec Section 6.2 (labeled `Repository:`, `Version:`, `Path:`, `Link:` lines). Populate the new Code item's `description` field at creation time. Reuse the same `:\d+-\d+$` regex from change 1 to split path-without-line-range from line range when constructing the GitHub-style URL (`https://<repo_origin>/blob/<code_version>/<path>#L<N>-L<M>` when line-range present; without `#L...` fragment when absent).

Unit tests added per spec Section 6.4: truncation regex correctness (basename preserved on non-line-range colons + regression on trailing `:N-M`), description-text format (with and without line range), and `repo_origin` propagation through to the request payload. Tests follow patterns in `tests/unit/jama_client/` and `tests/unit/jama_mcp_server/test_protocol.py`. Docstrings on both layers updated per spec Section 6.5 to reflect the new parameter, the description-population behavior, and the macro-vs-primitives asymmetry already noted there.

## Read first, in this order

1. `docs/superpowers/specs/2026-05-11-jama-mvp-dx-testing-design.md` — primary contract; Section 6 governs this work
2. `docs/superpowers/specs/2026-05-10-jama-mvp-build-design.md` — MVP build context (introduces `create_path_a_trace`)
3. `docs/superpowers/specs/2026-04-28-jama-mcp-server-design.md` — foundation architecture, two-layer error policy
4. `docs/runbooks/cloud-routine-config.md` — routine conventions you are executing under
5. `CLAUDE.md` — project conventions including Phase 1, 2, 4.5, and MVP build codified patterns; tooling rigor; repository visibility constraints
6. `MEMORY.md` — working state, Sandbox seed data, known issues (the truncation bug is noted there)
7. Existing code establishing patterns:
   - `src/jama_client/client.py` — the truncation logic and `create_path_a_trace` method live here
   - `src/jama_mcp_server/tools/workflow.py` — the MCP workflow tool wrapper
   - `tests/unit/jama_client/` — client unit-test patterns
   - `tests/unit/jama_mcp_server/test_protocol.py` — MCP-protocol test pattern using `mock_jama_client` and synthetic `RequestContext`

## Branching and pull request

- Branch off `main` (the working branch name is auto-generated by the platform on initial Trigger fire — the prompt's preference is cosmetic per the runbook's Trigger-vs-Session distinction)
- Pull request base: `main`
- Pull request title (verbatim): `feat: populate Code item description with deep link; fix name truncation`
- Pull request body must include, in this order:
  - `Closes #15` on its own line near the top
  - Two-to-three-sentence summary of the work
  - Checklist of acceptance criteria derived from spec Section 6
  - List of the four verification commands run with their pass status
  - A `## Routine prompt (reproducibility)` section containing this prompt verbatim in a collapsed `<details>` block
  - The `Routine-driven work` section from `.github/PULL_REQUEST_TEMPLATE.md` completed with run ID, design spec path, runbook path, prompt-archived checkbox
- Add a comment to issue #15 with a link to the pull request after the PR opens

## Verification before push

Run all four commands in sequence; all four must pass before push:

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest -m "not integration"`

Expected test count delta: current 119 unit/protocol tests plus 4–6 new tests for this PR.

## Stop-and-escalate conditions

Stop work and post a comment on the pull request (or on issue #15 if no PR has opened yet) under any of these conditions:

1. Test failures you cannot diagnose and fix in a single revision attempt — surface the failing test output, your attempted fix, and your hypothesis about why it is failing
2. Pre-commit hook failures (gitleaks, validate-docs-placement, ruff/mypy) that you cannot resolve by re-staging or fixing the staged content
3. The design specification at `docs/superpowers/specs/2026-05-11-jama-mvp-dx-testing-design.md` is ambiguous on a load-bearing decision — quote the spec language you find ambiguous and your two interpretations
4. The work requires adding a new dependency to `pyproject.toml` — surface the dependency name and rationale before adding

## What NOT to do

- Do NOT push to `main` directly
- Do NOT skip pre-commit hooks (`--no-verify`, `--no-gpg-sign`)
- Do NOT squash-merge the pull request (the operator merges)
- Do NOT modify files outside the spec's stated scope (limited to `src/jama_client/client.py`, `src/jama_mcp_server/tools/workflow.py`, new unit tests under `tests/unit/jama_client/` and `tests/unit/jama_mcp_server/`, and docstring edits in those files)
- Do NOT modify any of the existing 119 tests unless you discover a genuine bug; surface as stop condition 1 if you think one exists
- Do NOT run integration tests (Jama OAuth is not configured in the routine environment)
- Do NOT add multi-host repo-origin support (GitLab, Bitbucket); GitHub-style URL construction only per spec Section 6.2 and Section 9
- Do NOT add idempotency hardening to `create_path_a_trace`; that is recorded as out of scope in spec Section 9
- Do NOT add the "Generated with Claude Code" footer to commit messages; commits use the `Co-Authored-By:` line only
- Do NOT invoke any meta-skills (writing-plans, brainstorming, etc.); the spec is the implementation directive

## Commit message convention

Conventional Commits. Bundle related changes per logical unit. Each commit message ends with:

`Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`

Suggested commit sequence:
- `fix(jama-client): anchor create_path_a_trace name derivation on trailing line-range`
- `feat(jama-client): add repo_origin parameter and populate Code item description with deep link`
- `feat(jama-mcp-server): expose repo_origin on create_path_a_trace workflow tool`
- `test(jama-client): add unit tests for truncation regex and description population`
- `test(jama-mcp-server): add MCP-protocol tests for repo_origin parameter propagation`
- `docs(client): update docstrings on create_path_a_trace for repo_origin and deep-link description`

## Final action

Open the pull request against `main` with the title, body structure, and `Closes #15` directive above. Add a comment to issue #15 with a link to the pull request. Stop. Standing by for human review.
```

</details>

## Routine-driven work

- [x] Routine `claude.ai/code` run ID: `trig_018rCL9cxSTCMMySaeBsRJZm` (submitted 2026-05-11T16:40:00Z)
- [x] Routine submitted against design specification at: `docs/superpowers/specs/2026-05-11-jama-mvp-dx-testing-design.md`
- [x] Routine prompt archived in PR description body (collapsed `<details>` block) for reproducibility
- [x] Routine configuration matched `docs/runbooks/cloud-routine-config.md` defaults

## Notes

**One existing test assertion updated:** `test_create_path_a_trace_call_round_trips_via_protocol` in `tests/unit/jama_mcp_server/test_protocol.py` had its `assert_called_once_with` updated to include `repo_origin=None`. This is a direct consequence of adding the new parameter to the tool's interface — the assertion was incorrect (incomplete) after the interface change, not because of a pre-existing bug. All other 118 original tests pass unmodified.

**`repo_origin` typed as `str | None = None`:** The spec states `repo_origin: str` without specifying optionality. Using `str | None = None` is consistent with the existing `name: str | None = None` keyword-only pattern, keeps the parameter non-breaking for callers that do not yet supply a repository context, and aligns with the "no description when absent" semantics documented in the docstring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJQEca42LsXmdZFkZC5qwG)_