### PR TITLE
fix: HTML-wrap Code item description so deep link persists in Jama

### DIFF
--- a/src/jama_client/client.py
+++ b/src/jama_client/client.py
@@ -561,8 +561,10 @@ class JamaClient:
            (e.g. ``"src/client.py:7-42"`` → ``"client.py"``); mid-path colons
            (ISO timestamps, Windows-style paths, annotated identifiers) are
            preserved. When ``repo_origin`` is supplied, populates the item's
-           ``description`` field with a four-line deep link to the tagged code
-           (see ``repo_origin`` parameter description below).
+           ``description`` field with an HTML-formatted deep link to the
+           tagged code (see ``repo_origin`` parameter description below). The
+           HTML wrapping is required because Jama's Type 114 ``description``
+           field is RICHTEXT-typed and silently drops plain-text content.
         6. Creates the "Implemented by" relationship from the source requirement
            to the new Code item.
 
@@ -590,18 +592,22 @@ class JamaClient:
                 ``"github.com/arthurfantaci/jama-mcp-server"``. No leading
                 scheme; ``https://`` is prepended when constructing the deep
                 link. When supplied, the Code item's ``description`` field is
-                populated with:
+                populated with an HTML payload of the form:
 
-                .. code-block:: text
+                .. code-block:: html
 
-                    Repository: <repo_origin>
-                    Version: <code_version>
-                    Path: <path-without-line-range> (lines N-M)
-                    Link: https://<repo_origin>/blob/<code_version>/<path>#LN-LM
+                    <p>Repository: <repo_origin><br>
+                    Version: <code_version><br>
+                    Path: <path-without-line-range> (lines N-M)<br>
+                    Link: <a href="<url>"><url></a></p>
 
-                The ``Path:`` and ``Link:`` lines omit the ``(lines N-M)``
-                annotation and ``#LN-LM`` fragment when no line range is
-                present in ``code_path``. When ``None`` (default), no
+                where ``<url>`` is
+                ``https://<repo_origin>/blob/<code_version>/<path>#LN-LM``.
+                The ``Path:`` line omits the ``(lines N-M)`` annotation and
+                the URL omits the ``#LN-LM`` fragment when no line range is
+                present in ``code_path``. The link is wrapped in an explicit
+                ``<a href>`` so it is clickable in Jama's UI regardless of
+                tenant link-detection settings. When ``None`` (default), no
                 ``description`` field is set on the Code item.
             name: Optional override for the Code item's ``name`` field.
                 Defaults to the basename of ``code_path`` with any trailing
@@ -661,7 +667,10 @@ class JamaClient:
                 path_line = f"Path: {stripped_path}"
                 link = f"https://{repo_origin}/blob/{code_version}/{stripped_path}"
             code_fields["description"] = (
-                f"Repository: {repo_origin}\nVersion: {code_version}\n{path_line}\nLink: {link}"
+                f"<p>Repository: {repo_origin}<br>"
+                f"Version: {code_version}<br>"
+                f"{path_line}<br>"
+                f'Link: <a href="{link}">{link}</a></p>'
             )
 
         code_item = await self.create_item(

--- a/src/jama_mcp_server/tools/workflow.py
+++ b/src/jama_mcp_server/tools/workflow.py
@@ -64,15 +64,19 @@ def register(server: FastMCP) -> None:
            the basename of ``code_path`` with any trailing ``:N-M`` line-range
            suffix stripped (mid-path colons such as ISO timestamps are
            preserved). When ``repo_origin`` is supplied, also populates the
-           item ``description`` with a four-line deep link in the form::
+           item ``description`` with an HTML-formatted deep link in the form::
 
-               Repository: <repo_origin>
-               Version: <code_version>
-               Path: <path-without-range> (lines N-M)
-               Link: https://<repo_origin>/blob/<code_version>/<path>#LN-LM
+               <p>Repository: <repo_origin><br>
+               Version: <code_version><br>
+               Path: <path-without-range> (lines N-M)<br>
+               Link: <a href="<url>"><url></a></p>
 
-           The ``(lines N-M)`` annotation and ``#LN-LM`` fragment are omitted
-           when ``code_path`` carries no trailing line range.
+           where ``<url>`` is
+           ``https://<repo_origin>/blob/<code_version>/<path>#LN-LM``. The
+           HTML wrapping is required because Jama's ``description`` field on
+           Type 114 (Code) is RICHTEXT-typed and silently drops plain-text
+           content. The ``(lines N-M)`` annotation and ``#LN-LM`` fragment are
+           omitted when ``code_path`` carries no trailing line range.
         3. Creates an ``"Implemented by"`` relationship from the source
            requirement to the new Code item.
 

--- a/tests/unit/jama_client/test_client_dx_testing.py
+++ b/tests/unit/jama_client/test_client_dx_testing.py
@@ -81,8 +81,15 @@ async def test_name_derivation_strips_trailing_line_range() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_description_populated_with_line_range_matches_spec_format() -> None:
-    """Description matches the four-line spec format when a trailing line range is present."""
+async def test_description_populated_with_line_range_matches_html_format() -> None:
+    """Description is HTML-formatted with explicit anchor tag when a line range is present.
+
+    Jama's Type 114 ``description`` field is RICHTEXT-typed and silently drops
+    plain-text content on POST ``/items`` (verified against pm2.jamacloud.com
+    2026-05-11; tracked in issue #17). The HTML wrapping ensures the field
+    persists; the explicit ``<a href>`` tag ensures the link is clickable in
+    Jama's UI regardless of tenant link-detection settings.
+    """
     client = _make_client()
     await JamaClient.create_path_a_trace(
         client,
@@ -94,18 +101,25 @@ async def test_description_populated_with_line_range_matches_spec_format() -> No
     )
     call_kwargs = client.create_item.call_args.kwargs
     description: str = call_kwargs["fields"]["description"]
-    expected = (
-        "Repository: github.com/arthurfantaci/jama-mcp-server\n"
-        "Version: v1.0.0\n"
-        "Path: src/jama_mcp_server/tools/workflow.py (lines 78-130)\n"
-        "Link: https://github.com/arthurfantaci/jama-mcp-server"
+    url = (
+        "https://github.com/arthurfantaci/jama-mcp-server"
         "/blob/v1.0.0/src/jama_mcp_server/tools/workflow.py#L78-L130"
+    )
+    expected = (
+        "<p>Repository: github.com/arthurfantaci/jama-mcp-server<br>"
+        "Version: v1.0.0<br>"
+        "Path: src/jama_mcp_server/tools/workflow.py (lines 78-130)<br>"
+        f'Link: <a href="{url}">{url}</a></p>'
     )
     assert description == expected
 
 
 async def test_description_populated_without_line_range_omits_annotation_and_fragment() -> None:
-    """Description omits the ``(lines N-M)`` annotation and ``#LN-LM`` fragment when absent."""
+    """Description omits the ``(lines N-M)`` annotation and ``#LN-LM`` fragment when absent.
+
+    HTML wrapping is unchanged; only the ``Path:`` line and the URL itself
+    adapt to the missing line range.
+    """
     client = _make_client()
     await JamaClient.create_path_a_trace(
         client,
@@ -117,12 +131,12 @@ async def test_description_populated_without_line_range_omits_annotation_and_fra
     )
     call_kwargs = client.create_item.call_args.kwargs
     description: str = call_kwargs["fields"]["description"]
+    url = "https://github.com/arthurfantaci/jama-mcp-server/blob/v1.0.0/src/jama_client/client.py"
     expected = (
-        "Repository: github.com/arthurfantaci/jama-mcp-server\n"
-        "Version: v1.0.0\n"
-        "Path: src/jama_client/client.py\n"
-        "Link: https://github.com/arthurfantaci/jama-mcp-server"
-        "/blob/v1.0.0/src/jama_client/client.py"
+        "<p>Repository: github.com/arthurfantaci/jama-mcp-server<br>"
+        "Version: v1.0.0<br>"
+        "Path: src/jama_client/client.py<br>"
+        f'Link: <a href="{url}">{url}</a></p>'
     )
     assert description == expected
 


### PR DESCRIPTION
Closes #17.

## Summary

PR #16's `repo_origin` deep-link description population shipped with all unit/protocol tests passing but the feature did not work end-to-end against Jama. Live testing on 2026-05-11 against `pm2.jamacloud.com` (project 127) revealed that Jama silently drops the `description` field on POST `/items` for Type 114 Code items because the field is RICHTEXT-typed and rejects plain-text content. This PR HTML-wraps the description string so Jama persists it, and wraps the URL in an explicit `<a href>` tag so the link is clickable in Jama's UI regardless of tenant link-detection settings.

## Acceptance criteria

- [x] `JamaClient.create_path_a_trace` builds the description as `<p>...<br>...</p>` HTML with URL inside `<a href="...">...</a>`
- [x] Unit tests `test_description_populated_with_line_range_matches_html_format` and `test_description_populated_without_line_range_omits_annotation_and_fragment` assert the HTML payload
- [x] Docstrings on `JamaClient.create_path_a_trace` and the MCP workflow tool wrapper updated to note the HTML payload and the RICHTEXT rationale
- [x] All four convention-mandated commands pass
- [ ] Live verification post-merge: a fresh `create_path_a_trace` invocation produces a Code item whose `description` field returns the HTML payload via `get_item` (verified after merge)

## Verification

| Command | Result |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 36 files already formatted |
| `uv run mypy src/` | Success: no issues found in 13 source files |
| `uv run pytest -m "not integration"` | 126 passed, 7 deselected |

## Root cause analysis

`list_item_types(project_id=127)` confirms Type 114 (`CODE`) has a `description` field defined in its schema (field id 1078, `fieldType: TEXT`, `textType: RICHTEXT`, `readOnly: false`, `required: false`). The schema accepts the field; the rejection is at the RICHTEXT content layer.

Evidence the wrapping is what's missing: existing Subsystem Requirements in project 127 (`AF-SUBSS-25`, `AF-SUBSS-26`, `AF-SUBSS-27`) all store their descriptions as `<p>...</p>` HTML, matching Jama's RICHTEXT expectation. The `AF-CODE-9` item created during the pre-fix live test was the first to attempt plain-text content for a Code item description — and the first to demonstrate the silent drop.

## Why this escaped PR #16's tests

- Unit tests mocked `create_item` — they verified the workflow tool sends the right kwargs but did not verify Jama persists them.
- The DX testing scenario set didn't supply `repo_origin` (separately documented in `docs/superpowers/findings/2026-05-11-jama-mvp-dx-testing-findings.md` Section 4.1), so the description code path was never exercised end-to-end.
- A Jama-integration round-trip test (POST then GET, compare sent-vs-stored fields) would have caught this. Adding one is a recommended follow-up but separable from this hot-fix.

## Notes

- The original PR #16 design spec (`docs/superpowers/specs/2026-05-11-jama-mvp-dx-testing-design.md` Section 6.2) documented the plain-text format as the design intent. The spec is left unchanged as a historical design record; this PR's body is the corrective record.
- The HTML payload is functionally a superset of the original plain-text design: it preserves the four labelled lines and adds reliable click-through via the explicit `<a href>` tag.