### PR TITLE
docs: bundled DX-testing follow-ups (5.1, 5.4, 5.5, 5.6)

### DIFF
--- a/src/jama_client/client.py
+++ b/src/jama_client/client.py
@@ -565,6 +565,12 @@ class JamaClient:
            tagged code (see ``repo_origin`` parameter description below). The
            HTML wrapping is required because Jama's Type 114 ``description``
            field is RICHTEXT-typed and silently drops plain-text content.
+           When ``repo_origin`` is omitted, the Code item carries only
+           ``path$<typeId>`` and ``code_version$<typeId>`` — Jama reviewers
+           cannot navigate from Jama to the tagged code without external
+           knowledge of the repository origin. Supplying ``repo_origin``
+           is strongly recommended whenever the caller knows the origin
+           (typically derivable from ``git remote get-url origin``).
         6. Creates the "Implemented by" relationship from the source requirement
            to the new Code item.
 
@@ -587,12 +593,22 @@ class JamaClient:
                 treated as part of the path.
             code_version: Version string stored in the Code item's
                 ``code_version$<typeId>`` field (e.g. ``"v1.0.0-rc1"``).
+                Recommended values: a release tag (``"v1.0.0"``) or a
+                commit SHA (``"a1b2c3d"``). Branch names like ``"main"``
+                are weaker defaults because the resolved code shifts as
+                the branch advances; a tag or SHA produces a stable,
+                point-in-time reference suitable for audit.
             repo_origin: Optional ``<host>/<owner>/<repo>`` string identifying
                 the source repository, e.g.
                 ``"github.com/arthurfantaci/jama-mcp-server"``. No leading
                 scheme; ``https://`` is prepended when constructing the deep
-                link. When supplied, the Code item's ``description`` field is
-                populated with an HTML payload of the form:
+                link. Recommended value: derive from ``git remote get-url
+                origin`` by stripping the leading scheme (``https://`` or
+                ``git@``) and the trailing ``.git``. For example,
+                ``https://github.com/arthurfantaci/jama-mcp-server.git``
+                becomes ``github.com/arthurfantaci/jama-mcp-server``. When
+                supplied, the Code item's ``description`` field is populated
+                with an HTML payload of the form:
 
                 .. code-block:: html
 

--- a/src/jama_mcp_server/tools/core.py
+++ b/src/jama_mcp_server/tools/core.py
@@ -88,6 +88,21 @@ def register(server: FastMCP) -> None:
 
         Anticipates ``GET /rest/latest/abstractitems`` from Jama Connect MCP™.
         ``query`` is matched against item content as a free-text search.
+
+        Constraints (observed against Jamacloud):
+
+        * No singular/plural stemming — ``"requirement"`` does not match
+          items named ``"requirements"``. Tokens must match closely.
+        * Approximately exact-token matching, not semantic. A query
+          describing the *content* of a requirement (e.g. ``"HTTP errors
+          typed exceptions"``) will not match a requirement whose body
+          discusses that topic unless the exact tokens appear.
+        * Newly created items have a ~30s-few-minute search-index lag
+          before they become discoverable.
+
+        If ``search_items`` returns empty and the item type is known,
+        fall back to ``list_items_by_type(project_id, item_type)`` and
+        filter the result client-side.
         """
         items = await _client(ctx).search_items(project_id=project_id, query=query)
         return [item.model_dump() for item in items]
@@ -133,8 +148,11 @@ def register(server: FastMCP) -> None:
         ``"GENERAL"``) and no parent — ``inReplyTo`` is omitted from the
         request payload entirely (sending ``0`` triggers a server-side NPE
         on Jamacloud). Both ``item_id`` and ``project_id`` are required by
-        Jama's request schema; obtain ``project_id`` from a prior
-        ``get_item`` call's ``project`` field or from ``list_projects``.
+        Jama's request schema. When the caller already has ``project_id``
+        (e.g., from the developer's prompt or context), pass it directly —
+        no prior ``list_projects`` discovery call is needed. Otherwise,
+        obtain it from a prior ``get_item`` call's ``project`` field or
+        from ``list_projects``.
 
         Valid ``comment_type`` enum values per the Jama Swagger schema:
         ``"GENERAL"`` (default), ``"QUESTION"``, ``"PROPOSED_CHANGE"``,

--- a/src/jama_mcp_server/tools/workflow.py
+++ b/src/jama_mcp_server/tools/workflow.py
@@ -80,6 +80,25 @@ def register(server: FastMCP) -> None:
         3. Creates an ``"Implemented by"`` relationship from the source
            requirement to the new Code item.
 
+        Recommended values when constructing the call:
+
+        * ``code_version`` — a release tag (``"v1.0.0"``) or commit SHA
+          (``"a1b2c3d"``). Branch names like ``"main"`` are weaker
+          defaults because the resolved code shifts as the branch
+          advances; tags and SHAs produce stable, point-in-time
+          references suitable for audit.
+        * ``repo_origin`` — derive from ``git remote get-url origin``
+          by stripping the leading scheme and the trailing ``.git``. For
+          example, ``https://github.com/arthurfantaci/jama-mcp-server.git``
+          becomes ``github.com/arthurfantaci/jama-mcp-server``. When
+          omitted, the Code item carries no link back to source — Jama
+          reviewers cannot navigate from Jama to the tagged code without
+          external knowledge of the repository origin.
+
+        ``project_id`` should be passed directly when the caller has it
+        from context (e.g., the developer's prompt) — no prior
+        ``list_projects`` discovery call is needed.
+
         Type IDs and the Set ID default to project-discovery when omitted:
         ``code_item_type`` is resolved by ``typeKey == "CODE"``;
         ``relationship_type`` is resolved by name ``"Implemented by"``;


### PR DESCRIPTION
## Summary

Four docstring-only updates addressing findings from the DX testing phase report at `docs/superpowers/findings/2026-05-11-jama-mvp-dx-testing-findings.md`. No production code logic changes; no test logic changes. Bundled because all four are docstring touchpoints driven by the same findings document and share verification gates.

Tracked in `MEMORY.md`'s *Known follow-up items* section, not as a separate GitHub issue.

## Files edited

| File | Sections | Change |
|---|---|---|
| `src/jama_client/client.py` | 5.1, 5.5 | `JamaClient.create_path_a_trace` docstring: added \"Recommended value\" for `repo_origin` (derivation from `git remote get-url origin`), added \"Recommended values\" for `code_version` (release tag or commit SHA over branch names), added benefit statement about Jama-side navigability when `repo_origin` is supplied. |
| `src/jama_mcp_server/tools/workflow.py` | 5.1, 5.5, 5.6 | Workflow tool wrapper docstring: added \"Recommended values\" paragraph covering `code_version` and `repo_origin`, plus a clarifying note that `list_projects` discovery is not needed when `project_id` is already in the caller's context. |
| `src/jama_mcp_server/tools/core.py` | 5.4, 5.6 | `search_items` docstring: added \"Constraints\" section (no stemming, exact-token matching, index lag) and a fallback recommendation to `list_items_by_type`. `create_comment` docstring: added clarifying note about `list_projects` redundancy when `project_id` is known. |

## Verification

| Command | Result |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 36 files already formatted |
| `uv run mypy src/` | Success: no issues found in 13 source files |
| `uv run pytest -m \"not integration\"` | 126 passed, 7 deselected |

## Notes

This PR was originally scoped for delivery via a cloud routine on `#jama-mcp-dev`. The routine hung in container provisioning for 80+ minutes and was cancelled. The work was completed locally in this session to unblock demo prep. Lessons from the routine attempt are queued for a follow-up runbook commit (`docs/runbooks/cloud-routine-config.md` Section 4.x extensions: the `events[].data` nesting asymmetry, the `RemoteTrigger run` return shape, the model-field provisioning observation).

## Follow-up items still queued

After this PR merges, `MEMORY.md`'s *Known follow-up items* section will still list two items not addressed here:

- **5.2** — idempotency gap on `create_path_a_trace` (add optional `existing_code_item_id` parameter). Behavior change; warrants its own PR.
- **5.3** — improve MCP-server-side error surfacing (include raw HTTP status and Jama envelope in `JamaError` responses). Behavior change; warrants its own PR after deterministic reproduction of the Scenario 1 transient 409.